### PR TITLE
Fix: Use alsa instead of PA on headless

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,6 +62,21 @@
     state: restarted
   when: powermgmt_service is changed
 
+- name: disable pulseaudio service when headless
+  service:
+    name: pulseaudio.service
+    state: stopped
+    enabled: False
+  when:
+    - jukebox__headless
+
+# - name: disable pulseaudio socket when headless
+#   service:
+#     name: pulseaudio.socket
+#     enabled: False
+#   when:
+#     - jukebox__headless
+
 - name: Cancel splash rainbow /boot/config.txt
   lineinfile:
     path: /boot/config.txt

--- a/templates/mopidy.conf
+++ b/templates/mopidy.conf
@@ -8,7 +8,8 @@
 hostname = 0.0.0.0
 
 [audio]
-output = pulsesink server=127.0.0.1
+output = {% if jukebox__headless %}alsasink device=hw:0,0{% else %}pulsesink server=127.0.0.1{% endif %}
+
 
 [local]
 media_dir = {{ jukebox__media_dir }}


### PR DESCRIPTION
When headless system is used, better use Alsa sound instead of PulseAudio.